### PR TITLE
remove extra webfile test code

### DIFF
--- a/webfile_test.go
+++ b/webfile_test.go
@@ -10,10 +10,6 @@ import (
 )
 
 func TestWebFile(t *testing.T) {
-	http.HandleFunc("/my/url/content.txt", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "Hello world!")
-	})
-
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hello world!")
 	}))


### PR DESCRIPTION
This PR removes extra `WebFile` test code which was leftover after switching to `httptest`.