### PR TITLE
return url as AbsPath from WebFile to implement FileInfo

### DIFF
--- a/webfile.go
+++ b/webfile.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 )
 
 // WebFile is an implementation of File which reads it
@@ -61,4 +62,13 @@ func (wf *WebFile) Size() (int64, error) {
 	return wf.contentLength, nil
 }
 
+func (wf *WebFile) AbsPath() string {
+	return wf.url.String()
+}
+
+func (wf *WebFile) Stat() os.FileInfo {
+	return nil
+}
+
 var _ File = &WebFile{}
+var _ FileInfo = &WebFile{}


### PR DESCRIPTION
This PR extends `WebFile` to implement `FileInfo`, causing the `url` to be sent in the `abspath` header (to be used in subsequent PRs to `go-ipfs-cmds` and `go-ipfs`).
Towards https://github.com/ipfs/go-ipfs/issues/6065