### PR TITLE
check http status code during WebFile reads and return error for non-2XX

### DIFF
--- a/webfile.go
+++ b/webfile.go
@@ -2,6 +2,7 @@ package files
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -31,9 +32,13 @@ func NewWebFile(url *url.URL) *WebFile {
 // reads will keep reading from the HTTP Request body.
 func (wf *WebFile) Read(b []byte) (int, error) {
 	if wf.body == nil {
-		resp, err := http.Get(wf.url.String())
+		s := wf.url.String()
+		resp, err := http.Get(s)
 		if err != nil {
 			return 0, err
+		}
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			return 0, fmt.Errorf("got non-2XX status code %d: %s", resp.StatusCode, s)
 		}
 		wf.body = resp.Body
 		wf.contentLength = resp.ContentLength

--- a/webfile_test.go
+++ b/webfile_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 func TestWebFile(t *testing.T) {
+	const content = "Hello world!"
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "Hello world!")
+		fmt.Fprintf(w, content)
 	}))
 	defer s.Close()
 
@@ -24,7 +25,24 @@ func TestWebFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(body) != "Hello world!" {
-		t.Fatal("should have read the web file")
+	if string(body) != content {
+		t.Fatalf("expected %q but got %q", content, string(body))
+	}
+}
+
+func TestWebFile_notFound(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "File not found.", http.StatusNotFound)
+	}))
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wf := NewWebFile(u)
+	_, err = ioutil.ReadAll(wf)
+	if err == nil {
+		t.Fatal("expected error")
 	}
 }


### PR DESCRIPTION
This PR adds an HTTP status code check to `WebFile.Read` so that non-2XX codes return an error. Before this change, the body of an error response would be accepted as the content, so e.g. a user might add a url for an object in a *private* cloud storage bucket and the cluster/node would silently hash an error message about not having access (this is how I discovered this).