### PR TITLE
revert(symlink): keep stat argument

### DIFF
--- a/linkfile.go
+++ b/linkfile.go
@@ -1,17 +1,19 @@
 package files
 
 import (
+	"os"
 	"strings"
 )
 
 type Symlink struct {
 	Target string
 
+	stat   os.FileInfo
 	reader strings.Reader
 }
 
-func NewLinkFile(target string) File {
-	lf := &Symlink{Target: target}
+func NewLinkFile(target string, stat os.FileInfo) File {
+	lf := &Symlink{Target: target, stat: stat}
 	lf.reader.Reset(lf.Target)
 	return lf
 }

--- a/multipartfile.go
+++ b/multipartfile.go
@@ -99,7 +99,7 @@ func (w *multipartWalker) nextFile() (Node, error) {
 			return nil, err
 		}
 
-		return NewLinkFile(string(out)), nil
+		return NewLinkFile(string(out), nil), nil
 	default:
 		return &ReaderFile{
 			reader:  part,

--- a/serialfile.go
+++ b/serialfile.go
@@ -53,7 +53,7 @@ func NewSerialFile(path string, hidden bool, stat os.FileInfo) (Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		return NewLinkFile(target), nil
+		return NewLinkFile(target, stat), nil
 	default:
 		return nil, fmt.Errorf("unrecognized file type for %s: %s", path, mode.String())
 	}


### PR DESCRIPTION
I thought this wasn't used outside this package. Apparently, I didn't run grep from the right directory.

It doesn't _hurt_ to keep this.