### PR TITLE
Feat/add ignore rules

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,49 @@
+package files
+
+import (
+	"os"
+
+	ignore "github.com/crackcomm/go-gitignore"
+)
+
+// Filter represents a set of rules for determining if a file should be included or excluded.
+// A rule follows the syntax for patterns used in .gitgnore files for specifying untracked files.
+// Examples:
+// foo.txt
+// *.app
+// bar/
+// **/baz
+// fizz/**
+type Filter struct {
+	// IncludeHidden - Include hidden files
+	IncludeHidden bool
+	// Rules - File filter rules
+	Rules *ignore.GitIgnore
+}
+
+// NewFilter creates a new file filter from a .gitignore file and/or a list of ignore rules.
+// An ignoreFile is a path to a file with .gitignore-style patterns to exclude, one per line
+// rules is an array of strings representing .gitignore-style patterns
+// For reference on ignore rule syntax, see https://git-scm.com/docs/gitignore
+func NewFilter(ignoreFile string, rules []string, includeHidden bool) (*Filter, error) {
+	var ignoreRules *ignore.GitIgnore
+	var err error
+	if ignoreFile == "" {
+		ignoreRules, err = ignore.CompileIgnoreLines(rules...)
+	} else {
+		ignoreRules, err = ignore.CompileIgnoreFileAndLines(ignoreFile, rules...)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &Filter{IncludeHidden: includeHidden, Rules: ignoreRules}, nil
+}
+
+// ShouldExclude takes an os.FileInfo object and applies rules to determine if its target should be excluded.
+func (filter *Filter) ShouldExclude(fileInfo os.FileInfo) (result bool) {
+	path := fileInfo.Name()
+	if !filter.IncludeHidden && isHidden(fileInfo) {
+		return true
+	}
+	return filter.Rules.MatchesPath(path)
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,50 @@
+package files
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type mockFileInfo struct {
+	os.FileInfo
+	name string
+}
+
+func (m *mockFileInfo) Name() string {
+	return m.name
+}
+
+var _ os.FileInfo = &mockFileInfo{}
+
+func TestFileFilter(t *testing.T) {
+	includeHidden := true
+	filter, err := NewFilter("", nil, includeHidden)
+	if err != nil {
+		t.Errorf("failed to create filter with empty rules")
+	}
+	if filter.IncludeHidden != includeHidden {
+		t.Errorf("new filter should include hidden files")
+	}
+	_, err = NewFilter("ignoreFileThatDoesNotExist", nil, false)
+	if err == nil {
+		t.Errorf("creating a filter without an invalid ignore file path should have failed")
+	}
+	tmppath, err := ioutil.TempDir("", "filter-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ignoreFilePath := filepath.Join(tmppath, "ignoreFile")
+	ignoreFileContents := []byte("a.txt")
+	if err := ioutil.WriteFile(ignoreFilePath, ignoreFileContents, 0666); err != nil {
+		t.Fatal(err)
+	}
+	filterWithIgnoreFile, err := NewFilter(ignoreFilePath, nil, false)
+	if err != nil {
+		t.Errorf("failed to create filter with ignore file")
+	}
+	if !filterWithIgnoreFile.ShouldExclude(&mockFileInfo{name: "a.txt"}) {
+		t.Errorf("filter should've excluded expected file from ignoreFile: %s", "a.txt")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/ipfs/go-ipfs-files
 
-require golang.org/x/sys v0.0.0-20190302025703-b6889370fb10
+require (
+	github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3
+	golang.org/x/sys v0.0.0-20190302025703-b6889370fb10
+)
 
 go 1.12

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3 h1:HVTnpeuvF6Owjd5mniCL8DEXo7uYXdQEmOP4FJbV5tg=
+github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3/go.mod h1:p1d6YEZWvFzEh4KLyvBcVSnrfNDDvK2zfK/4x2v/4pE=
 golang.org/x/sys v0.0.0-20190302025703-b6889370fb10 h1:xQJI9OEiErEQ++DoXOHqEpzsGMrAv2Q2jyCpi7DmfpQ=
 golang.org/x/sys v0.0.0-20190302025703-b6889370fb10/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
This PR adds a `Filter` object that can be used to define rules for which files should be ignored during ipfs file commands. It also updates the `serialFile` type to use a filter to determine which files should be included. This is the first PR toward the re-implementation of the file ignore feature in go-ipfs: https://github.com/ipfs/go-ipfs/issues/3643