### PR TITLE
Refactor the go-ipfs-files API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Documentation
 
-https://godoc.org/github.com/ipfs/go-ipfs-files
+https://pkg.go.dev/github.com/ipfs/go-ipfs-files
 
 ## Contribute
 
@@ -28,4 +28,3 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 ## License
 
 MIT
-

--- a/file.go
+++ b/file.go
@@ -6,6 +6,7 @@ import (
 	"os"
 )
 
+// Error types
 var (
 	ErrNotDirectory = errors.New("file isn't a directory")
 	ErrNotReader    = errors.New("file isn't a regular file")
@@ -23,7 +24,7 @@ type Node interface {
 	Size() (int64, error)
 }
 
-// Node represents a regular Unix file
+// File represents a regular Unix file
 type File interface {
 	Node
 

--- a/linkfile.go
+++ b/linkfile.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 )
 
+// Symlink ...
 type Symlink struct {
 	Target string
 
@@ -12,28 +13,34 @@ type Symlink struct {
 	reader strings.Reader
 }
 
+// NewLinkFile ...
 func NewLinkFile(target string, stat os.FileInfo) File {
 	lf := &Symlink{Target: target, stat: stat}
 	lf.reader.Reset(lf.Target)
 	return lf
 }
 
+// Close ...
 func (lf *Symlink) Close() error {
 	return nil
 }
 
+// Read ...
 func (lf *Symlink) Read(b []byte) (int, error) {
 	return lf.reader.Read(b)
 }
 
+// Seek ...
 func (lf *Symlink) Seek(offset int64, whence int) (int64, error) {
 	return lf.reader.Seek(offset, whence)
 }
 
+// Size ...
 func (lf *Symlink) Size() (int64, error) {
 	return lf.reader.Size(), nil
 }
 
+// ToSymlink ...
 func ToSymlink(n Node) *Symlink {
 	l, _ := n.(*Symlink)
 	return l

--- a/multipartfile.go
+++ b/multipartfile.go
@@ -70,12 +70,12 @@ func NewFileFromPartReader(reader *multipart.Reader, mediatype string) (Director
 	}, nil
 }
 
-func (w *multipartWalker) nextFile() (Node, error) {
+func (m *multipartWalker) nextFile() (Node, error) {
 	part, err := w.getPart()
 	if err != nil {
 		return nil, err
 	}
-	w.consumePart()
+	m.consumePart()
 
 	contentType := part.Header.Get(contentTypeHeader)
 	if contentType != "" {
@@ -91,7 +91,7 @@ func (w *multipartWalker) nextFile() (Node, error) {
 		return &multipartDirectory{
 			part:   part,
 			path:   fileName(part),
-			walker: w,
+			walker: m,
 		}, nil
 	case applicationSymlink:
 		out, err := ioutil.ReadAll(part)

--- a/readerfile.go
+++ b/readerfile.go
@@ -18,14 +18,17 @@ type ReaderFile struct {
 	fsize int64
 }
 
+// NewBytesFile ...
 func NewBytesFile(b []byte) File {
 	return &ReaderFile{"", NewReaderFile(bytes.NewReader(b)), nil, int64(len(b))}
 }
 
+// NewReaderFile ...
 func NewReaderFile(reader io.Reader) File {
 	return NewReaderStatFile(reader, nil)
 }
 
+// NewReaderStatFile ...
 func NewReaderStatFile(reader io.Reader, stat os.FileInfo) File {
 	rc, ok := reader.(io.ReadCloser)
 	if !ok {
@@ -35,6 +38,7 @@ func NewReaderStatFile(reader io.Reader, stat os.FileInfo) File {
 	return &ReaderFile{"", rc, stat, -1}
 }
 
+// NewReaderPathFile ...
 func NewReaderPathFile(path string, reader io.ReadCloser, stat os.FileInfo) (*ReaderFile, error) {
 	abspath, err := filepath.Abs(path)
 	if err != nil {
@@ -44,22 +48,27 @@ func NewReaderPathFile(path string, reader io.ReadCloser, stat os.FileInfo) (*Re
 	return &ReaderFile{abspath, reader, stat, -1}, nil
 }
 
+// AbsPath ...
 func (f *ReaderFile) AbsPath() string {
 	return f.abspath
 }
 
+// Read ...
 func (f *ReaderFile) Read(p []byte) (int, error) {
 	return f.reader.Read(p)
 }
 
+// Close ...
 func (f *ReaderFile) Close() error {
 	return f.reader.Close()
 }
 
+// Stat ...
 func (f *ReaderFile) Stat() os.FileInfo {
 	return f.stat
 }
 
+// Size ...
 func (f *ReaderFile) Size() (int64, error) {
 	if f.stat == nil {
 		if f.fsize >= 0 {
@@ -70,6 +79,7 @@ func (f *ReaderFile) Size() (int64, error) {
 	return f.stat.Size(), nil
 }
 
+// Seek ...
 func (f *ReaderFile) Seek(offset int64, whence int) (int64, error) {
 	if s, ok := f.reader.(io.Seeker); ok {
 		return s.Seek(offset, whence)

--- a/serialfile.go
+++ b/serialfile.go
@@ -31,7 +31,7 @@ type serialIterator struct {
 	err error
 }
 
-// TODO: test/document limitations
+// NewSerialFile ... TODO: test/document limitations
 func NewSerialFile(path string, hidden bool, stat os.FileInfo) (Node, error) {
 	switch mode := stat.Mode(); {
 	case mode.IsRegular():

--- a/slicedirectory.go
+++ b/slicedirectory.go
@@ -15,6 +15,7 @@ func (e fileEntry) Node() Node {
 	return e.file
 }
 
+// FileEntry ...
 func FileEntry(name string, file Node) DirEntry {
 	return fileEntry{
 		name: name,
@@ -51,6 +52,7 @@ type SliceFile struct {
 	files []DirEntry
 }
 
+// NewMapDirectory ...
 func NewMapDirectory(f map[string]Node) Directory {
 	ents := make([]DirEntry, 0, len(f))
 	for name, nd := range f {
@@ -63,22 +65,27 @@ func NewMapDirectory(f map[string]Node) Directory {
 	return NewSliceDirectory(ents)
 }
 
+// NewSliceDirectory ...
 func NewSliceDirectory(files []DirEntry) Directory {
 	return &SliceFile{files}
 }
 
+// Entries ...
 func (f *SliceFile) Entries() DirIterator {
 	return &sliceIterator{files: f.files, n: -1}
 }
 
+// Close ...
 func (f *SliceFile) Close() error {
 	return nil
 }
 
+// Length ...
 func (f *SliceFile) Length() int {
 	return len(f.files)
 }
 
+// Size ...
 func (f *SliceFile) Size() (int64, error) {
 	var size int64
 

--- a/tarwriter.go
+++ b/tarwriter.go
@@ -8,6 +8,7 @@ import (
 	"time"
 )
 
+// TarWriter ...
 type TarWriter struct {
 	TarW *tar.Writer
 }
@@ -50,7 +51,7 @@ func (w *TarWriter) writeFile(f File, fpath string) error {
 	return nil
 }
 
-// WriteNode adds a node to the archive.
+// WriteFile adds a node to the archive.
 func (w *TarWriter) WriteFile(nd Node, fpath string) error {
 	switch nd := nd.(type) {
 	case *Symlink:

--- a/webfile.go
+++ b/webfile.go
@@ -61,11 +61,12 @@ func (wf *WebFile) Close() error {
 	return wf.body.Close()
 }
 
-// TODO: implement
+// Seek ... TODO: implement
 func (wf *WebFile) Seek(offset int64, whence int) (int64, error) {
 	return 0, ErrNotSupported
 }
 
+// Size ...
 func (wf *WebFile) Size() (int64, error) {
 	if err := wf.start(); err != nil {
 		return 0, err
@@ -77,10 +78,12 @@ func (wf *WebFile) Size() (int64, error) {
 	return wf.contentLength, nil
 }
 
+// AbsPath ...
 func (wf *WebFile) AbsPath() string {
 	return wf.url.String()
 }
 
+// Stat ...
 func (wf *WebFile) Stat() os.FileInfo {
 	return nil
 }


### PR DESCRIPTION
As we make progress in auditing and understanding the design of go-ipfs-files with the [Audit](https://docs.google.com/document/d/1Fwa49Jh3jNlNaqZwsOGH_YNZ5pWppch2Dc1f4nftGEQ/edit#heading=h.lsqidl2q1elv), I intend to capture action items that I'll list here, so that these can tackled. Step by step, commit by commit :) 


### Action items

- [x] Get the linter to get quiet and happy
- [ ] Refactor constructors to have consistent naming:
  - Use `New` for creation that doesn't do any IO or spins go routines
  - Use `Create` for creation that doesn't do any IO or spins go routines
  - Use `To` if we are converting to something else (e.g. DirEntry To File)
  - Use `From` if we are converting something else to the Type (e.g. File to DirEntry)