### PR TITLE
initial support for Mode and ModTime on Node interface

### DIFF
--- a/file.go
+++ b/file.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"time"
 )
 
 var (
@@ -16,6 +17,14 @@ var (
 // Node is a common interface for files, directories and other special files
 type Node interface {
 	io.Closer
+
+	// Mode returns the file's mode
+	Mode() os.FileMode
+
+	// ModTime returns the files last modification time.
+	//
+	// If the last modification time is unknown/unspecified the mtime is the Unix epoch (default timestamp).
+	ModTime() (mtime time.Time)
 
 	// Size returns size of this file (if this file is a directory, total size of
 	// all files stored in the tree should be returned). Some implementations may

--- a/linkfile.go
+++ b/linkfile.go
@@ -3,6 +3,7 @@ package files
 import (
 	"os"
 	"strings"
+	"time"
 )
 
 type Symlink struct {
@@ -16,6 +17,14 @@ func NewLinkFile(target string, stat os.FileInfo) File {
 	lf := &Symlink{Target: target, stat: stat}
 	lf.reader.Reset(lf.Target)
 	return lf
+}
+
+func (lf *Symlink) Mode() os.FileMode {
+	panic("Implement me")
+}
+
+func (lf *Symlink) ModTime() time.Time {
+	panic("Implement me")
 }
 
 func (lf *Symlink) Close() error {

--- a/multipartfile.go
+++ b/multipartfile.go
@@ -6,8 +6,10 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/url"
+	"os"
 	"path"
 	"strings"
+	"time"
 )
 
 const (
@@ -27,6 +29,14 @@ type multipartDirectory struct {
 
 	// part is the part describing the directory. It's nil when implicit.
 	part *multipart.Part
+}
+
+func (f *multipartDirectory) Mode() os.FileMode {
+	panic("implement me")
+}
+
+func (f *multipartDirectory) ModTime() time.Time {
+	panic("implement me")
 }
 
 type multipartWalker struct {

--- a/readerfile.go
+++ b/readerfile.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // ReaderFile is a implementation of File created from an `io.Reader`.
@@ -16,6 +17,14 @@ type ReaderFile struct {
 	stat    os.FileInfo
 
 	fsize int64
+}
+
+func (f *ReaderFile) Mode() os.FileMode {
+	return f.stat.Mode()
+}
+
+func (f *ReaderFile) ModTime() time.Time {
+	return f.stat.ModTime()
 }
 
 func NewBytesFile(b []byte) File {

--- a/serialfile.go
+++ b/serialfile.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // serialFile implements Node, and reads from a path on the OS filesystem.
@@ -154,6 +155,14 @@ func (f *serialFile) Size() (int64, error) {
 	})
 
 	return du, err
+}
+
+func (f *serialFile) Mode() os.FileMode {
+	panic("implement me")
+}
+
+func (f *serialFile) ModTime() time.Time {
+	panic("implement me")
 }
 
 var _ Directory = &serialFile{}

--- a/slicedirectory.go
+++ b/slicedirectory.go
@@ -1,6 +1,10 @@
 package files
 
-import "sort"
+import (
+	"os"
+	"sort"
+	"time"
+)
 
 type fileEntry struct {
 	name string
@@ -49,6 +53,14 @@ func (it *sliceIterator) Err() error {
 // SliceFiles are always directories, and can't be read from or closed.
 type SliceFile struct {
 	files []DirEntry
+}
+
+func (f *SliceFile) Mode() os.FileMode {
+	panic("implement me")
+}
+
+func (f *SliceFile) ModTime() time.Time {
+	panic("implement me")
 }
 
 func NewMapDirectory(f map[string]Node) Directory {

--- a/webfile.go
+++ b/webfile.go
@@ -7,7 +7,15 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
+	"time"
 )
+
+// the HTTP Response header that provides the last modified timestamp
+const lastModifiedHeaderName = "Last-Modified"
+
+// the HTTP Response header that provides the unix file mode
+const fileModeHeaderName = "X-FileMode"
 
 // WebFile is an implementation of File which reads it
 // from a Web URL (http). A GET request will be performed
@@ -16,6 +24,16 @@ type WebFile struct {
 	body          io.ReadCloser
 	url           *url.URL
 	contentLength int64
+	mode          os.FileMode
+	mtime         time.Time
+}
+
+func (wf *WebFile) Mode() os.FileMode {
+	return wf.mode
+}
+
+func (wf *WebFile) ModTime() time.Time {
+	return wf.mtime
 }
 
 // NewWebFile creates a WebFile with the given URL, which
@@ -38,8 +56,28 @@ func (wf *WebFile) start() error {
 		}
 		wf.body = resp.Body
 		wf.contentLength = resp.ContentLength
+		wf.getResponseMetaData(resp)
 	}
 	return nil
+}
+
+func (wf *WebFile) getResponseMetaData(resp *http.Response) {
+	ts := resp.Header.Get(lastModifiedHeaderName)
+	if ts != "" {
+		if mtime, err := time.Parse(time.RFC1123, ts); err != nil {
+			fmt.Printf("failed to parse %s header: %s\n", lastModifiedHeaderName, err.Error())
+		} else {
+			wf.mtime = mtime
+		}
+	}
+	md := resp.Header.Get(fileModeHeaderName)
+	if md != "" {
+		if mode, err := strconv.ParseInt(md, 8, 32); err != nil {
+			fmt.Printf("failed to parse %s header: %s\n", fileModeHeaderName, err.Error())
+		} else {
+			wf.mode = os.FileMode(mode)
+		}
+	}
 }
 
 // Read reads the File from it's web location. On the first


### PR DESCRIPTION
With this commit there is preliminary Mode and ModTime
support for single filesystem files and webfiles.

relates to ipfs/go-ipfs/issues/6920