### PR TITLE
fix: round timestamps down by truncating them to seconds

### DIFF
--- a/tarwriter.go
+++ b/tarwriter.go
@@ -74,7 +74,7 @@ func writeDirHeader(w *tar.Writer, fpath string) error {
 		Name:     fpath,
 		Typeflag: tar.TypeDir,
 		Mode:     0777,
-		ModTime:  time.Now(),
+		ModTime:  time.Now().Truncate(time.Second),
 		// TODO: set mode, dates, etc. when added to unixFS
 	})
 }
@@ -85,7 +85,7 @@ func writeFileHeader(w *tar.Writer, fpath string, size uint64) error {
 		Size:     int64(size),
 		Typeflag: tar.TypeReg,
 		Mode:     0644,
-		ModTime:  time.Now(),
+		ModTime:  time.Now().Truncate(time.Second),
 		// TODO: set mode, dates, etc. when added to unixFS
 	})
 }

--- a/tarwriter_test.go
+++ b/tarwriter_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"io"
 	"testing"
+	"time"
 )
 
 func TestTarWriter(t *testing.T) {
@@ -41,6 +42,10 @@ func TestTarWriter(t *testing.T) {
 		}
 		if cur.Size != size {
 			t.Errorf("got wrong size: %d != %d", cur.Size, size)
+		}
+		now := time.Now()
+		if cur.ModTime.After(now) {
+			t.Errorf("wrote timestamp in the future: %s (now) < %s", now, cur.ModTime)
 		}
 	}
 


### PR DESCRIPTION
Otherwise, we'll write timestamps in the future.

fixes https://github.com/ipfs/go-ipfs/issues/8406