### PR TITLE
fix: add dragonfly build option for filewriter flags

### DIFF
--- a/filewriter_unix.go
+++ b/filewriter_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || linux || netbsd || openbsd || freebsd
-// +build darwin linux netbsd openbsd freebsd
+//go:build darwin || linux || netbsd || openbsd || freebsd || dragonfly
+// +build darwin linux netbsd openbsd freebsd dragonfly
 
 package files
 


### PR DESCRIPTION
Hi,

I found building the dragonfly binary is also not supported during these [runs](https://github.com/wabarc/rivet/runs/4912918889); I fixed it, and the [runs](https://github.com/wabarc/rivet/runs/4912932119) are now successful.

releated #48