### PR TITLE
chore(Directory): add DirIterator API restriction: iterate only once

### DIFF
--- a/file.go
+++ b/file.go
@@ -63,7 +63,9 @@ type DirIterator interface {
 type Directory interface {
 	Node
 
-	// Entries returns a stateful iterator over directory entries.
+	// Entries returns a stateful iterator over directory entries. The iterator
+	// may consume the Directory state so it must be called only once (this
+	// applies specifically to the multipartIterator).
 	//
 	// Example usage:
 	//


### PR DESCRIPTION
Closes https://github.com/ipfs/go-ipfs-files/issues/53.

We can't really fix this in a simple way so at least flag the restriction in the docs.