### PR TITLE
fix: error when TAR has files outside of root

### DIFF
--- a/tarwriter.go
+++ b/tarwriter.go
@@ -59,7 +59,7 @@ func (w *TarWriter) writeFile(f File, fpath string) error {
 }
 
 func validateTarFilePath(baseDir, fpath string) bool {
-	// Ensure the filepath has no ".", "..", etc within the known filepath.
+	// Ensure the filepath has no ".", "..", etc within the known root directory.
 	fpath = path.Clean(fpath)
 
 	// If we have a non-empty baseDir, check if the filepath starts with baseDir.

--- a/tarwriter.go
+++ b/tarwriter.go
@@ -69,10 +69,9 @@ func validateTarFilePath(baseDir, fpath string) bool {
 		return false
 	}
 
-	// If there is no defined baseDir, i.e., if there's multiple files in the
-	// root, check if paths contain elements that would otherwise make them fall
-	// outside the root.
-	if strings.Contains(fpath, "..") {
+	// Otherwise, check if the path starts with '..' which would make it fall
+	// outside the root path. This works since the path has already been cleaned.
+	if strings.HasPrefix(fpath, "..") {
 		return false
 	}
 

--- a/tarwriter_test.go
+++ b/tarwriter_test.go
@@ -2,6 +2,7 @@ package files
 
 import (
 	"archive/tar"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -81,5 +82,68 @@ func TestTarWriter(t *testing.T) {
 
 	if cur, err = tr.Next(); err != io.EOF {
 		t.Fatal(err)
+	}
+}
+
+func TestTarWriterRelativePathInsideRoot(t *testing.T) {
+	tf := NewMapDirectory(map[string]Node{
+		"file.txt": NewBytesFile([]byte(text)),
+		"boop": NewMapDirectory(map[string]Node{
+			"../a.txt": NewBytesFile([]byte("bleep")),
+			"b.txt":    NewBytesFile([]byte("bloop")),
+		}),
+		"beep.txt": NewBytesFile([]byte("beep")),
+	})
+
+	tw, err := NewTarWriter(io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer tw.Close()
+	if err := tw.WriteFile(tf, ""); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTarWriterFailsFileOutsideRoot(t *testing.T) {
+	tf := NewMapDirectory(map[string]Node{
+		"file.txt": NewBytesFile([]byte(text)),
+		"boop": NewMapDirectory(map[string]Node{
+			"../../a.txt": NewBytesFile([]byte("bleep")),
+			"b.txt":       NewBytesFile([]byte("bloop")),
+		}),
+		"beep.txt": NewBytesFile([]byte("beep")),
+	})
+
+	tw, err := NewTarWriter(io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer tw.Close()
+	if err := tw.WriteFile(tf, ""); !errors.Is(err, ErrUnixFSPathOutsideRoot) {
+		t.Error(err)
+	}
+}
+
+func TestTarWriterFailsFileOutsideRootWithBaseDir(t *testing.T) {
+	tf := NewMapDirectory(map[string]Node{
+		"../file.txt": NewBytesFile([]byte(text)),
+		"boop": NewMapDirectory(map[string]Node{
+			"a.txt": NewBytesFile([]byte("bleep")),
+			"b.txt": NewBytesFile([]byte("bloop")),
+		}),
+		"beep.txt": NewBytesFile([]byte("beep")),
+	})
+
+	tw, err := NewTarWriter(io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer tw.Close()
+	if err := tw.WriteFile(tf, "test.tar"); !errors.Is(err, ErrUnixFSPathOutsideRoot) {
+		t.Error(err)
 	}
 }

--- a/tarwriter_test.go
+++ b/tarwriter_test.go
@@ -123,7 +123,7 @@ func TestTarWriterFailsFileOutsideRoot(t *testing.T) {
 
 	defer tw.Close()
 	if err := tw.WriteFile(tf, ""); !errors.Is(err, ErrUnixFSPathOutsideRoot) {
-		t.Error(err)
+		t.Errorf("unexpected error, wanted: %v; got: %v", ErrUnixFSPathOutsideRoot, err)
 	}
 }
 
@@ -144,6 +144,6 @@ func TestTarWriterFailsFileOutsideRootWithBaseDir(t *testing.T) {
 
 	defer tw.Close()
 	if err := tw.WriteFile(tf, "test.tar"); !errors.Is(err, ErrUnixFSPathOutsideRoot) {
-		t.Error(err)
+		t.Errorf("unexpected error, wanted: %v; got: %v", ErrUnixFSPathOutsideRoot, err)
 	}
 }


### PR DESCRIPTION
See https://github.com/ipfs/kubo/pull/9029 and the “Security” section added in IPIP-288 (https://github.com/ipfs/specs/pull/288)

This will affect both `ipfs get [--archive]`, as well as the new gateway TAR download format.

/cc @lidel 