### PR TITLE
Release v0.2.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.1.1"
+  "version": "v0.2.0"
 }


### PR DESCRIPTION
Bumping to v0.2.0 since #56 introduces restrictions around the way paths are validated by TAR writer.